### PR TITLE
Fixed typo in git repo address

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Lima MUD that work with fluffos v2019
 
 # How to test and contribute
 ```
-git clone --recurse-submodules https://github.com/flfufos/lima
+git clone --recurse-submodules https://github.com/fluffos/lima
 cd lima
 ./build.sh
 ./run.sh


### PR DESCRIPTION
This makes the README instructions work when copying and pasting.