### PR TITLE
Fixes for array keyword, part 1

### DIFF
--- a/lib/WWW/cgi/autodoc.c
+++ b/lib/WWW/cgi/autodoc.c
@@ -202,7 +202,7 @@ string object_summary_line(string arg)
 
 string handle_overview(string part)
 {
-  string *tmp;
+  mixed *tmp;
     
   string ret = @END
 <title>Mudlib Overview</title>

--- a/lib/WWW/cgi/mudinfo.c
+++ b/lib/WWW/cgi/mudinfo.c
@@ -65,7 +65,7 @@ string main (string pattern)
   {
     ret += "<h3>Which of the following muds are you looking for?</h3>"
       "<br><font size=+1><em>";
-    foreach (mudname in sort_*(keys (mudlist), 1))
+    foreach (mudname in sort_array(keys (mudlist), 1))
     {
 //      ret += sprintf ("<a href=http://%s:%d/cgi/mudinfo.c?=%s$>%s</a><br>",
 //		      __HOST__, PORT_HTTP, mudname, mudname);

--- a/lib/WWW/cgi/mudlist.c
+++ b/lib/WWW/cgi/mudlist.c
@@ -43,13 +43,13 @@ private string mail_link(string s)
 
 string main(string pattern) 
 {
-  string	ret = "";
-  mapping	mudlist	= IMUD_D->query_mudlist();
-  int		nummuds = sizeof(mudlist);
-  string * muds = keys(mudlist);
-  mixed *	data;
-  string * matches;
-  mixed * arg;
+  string        ret = "";
+  mapping       mudlist	= IMUD_D->query_mudlist();
+  int           nummuds = sizeof(mudlist);
+  string        *muds = keys(mudlist);
+  mixed         *data;
+  string        *matches;
+  mixed         *arg;
 
   if ( !pattern )
     matches = muds;

--- a/lib/cmds/create/addexit.c
+++ b/lib/cmds/create/addexit.c
@@ -17,7 +17,7 @@ private string reverse(string dir) {
     }
 }
 
-private void main(mixed *args) {
+private void main(string *args) {
     string dir = args[0];
     string where = args[1];
     string fname;

--- a/lib/cmds/create/newroom.c
+++ b/lib/cmds/create/newroom.c
@@ -2,7 +2,7 @@
 
 inherit CMD;
 
-private void main(mixed *args) {
+private void main(string *args) {
     string fname = args[0];
     
     if (fname[4..] != ".scr")

--- a/lib/cmds/create/setbrief.c
+++ b/lib/cmds/create/setbrief.c
@@ -2,7 +2,7 @@
 
 inherit __DIR__ "scr_command";    
 
-private void main(mixed *args) {
+private void main(string *args) {
     string brief = implode(args[0], " ");
     string fname;
     

--- a/lib/cmds/player/messages.c
+++ b/lib/cmds/player/messages.c
@@ -28,7 +28,7 @@ void update_translations() {
      * chooses the second when there is an overlap.
      */
     colours = ANSI_D->defaults() + colours;
-    if (this_user()->query_shell_ob()->get_variable("ansi"))
+    if (query_shell_ob()->get_variable("ansi"))
 	translations = ANSI_D->query_translations()[0];
     else
 	translations = ANSI_D->query_translations()[1];
@@ -51,11 +51,11 @@ void set_colour(string which, string what) {
     save_me();
 }
 
-string query_colour(string which) {
+void query_colour(string which) {
     return colours[which];
 }
 
-string *query_colours() {
+mixed *query_colours() {
     return keys(colours);
 }
 

--- a/lib/cmds/player/mudlist.c
+++ b/lib/cmds/player/mudlist.c
@@ -21,7 +21,7 @@ inherit M_REGEX;
 
 /*
 ** Pairs of info for each column.  ( header-index, field-width )
-** The header indices can be seen from the headers[] *below.
+** The header indices can be seen from the headers[] array below.
 **
 ** NOTE: at the moment, the first two elements must specify the "Up"
 **       state and the mud name

--- a/lib/cmds/verbs/get.c
+++ b/lib/cmds/verbs/get.c
@@ -79,7 +79,7 @@ void do_get_obj_from_obj(object ob1, object ob2)
   get_one(ob1, 0, 0);
 }
 
-void do_get_obs_from_obj(string *info, object ob2)
+void do_get_obs_from_obj(object *info, object ob2)
 {
   handle_obs(info, (
                        : get_one:));
@@ -90,7 +90,7 @@ void do_get_obj_from_wrd_obj(object ob1, string rel, object ob2)
   get_one(ob1, 0, rel);
 }
 
-void do_get_obs_from_wrd_obj(string *info, string rel, object ob2)
+void do_get_obs_from_wrd_obj(object *info, string rel, object ob2)
 {
   handle_obs(info, (
                        : get_one:),
@@ -102,7 +102,7 @@ void do_get_obj_out_of_obj(object ob1, object ob2)
   get_one(ob1, 0, 0);
 }
 
-void do_get_obs_out_of_obj(string *info, object ob2)
+void do_get_obs_out_of_obj(object *info, object ob2)
 {
   handle_obs(info, (
                        : get_one:));

--- a/lib/cmds/verbs/give.c
+++ b/lib/cmds/verbs/give.c
@@ -13,7 +13,7 @@ void do_give_obj_to_liv(object ob, object liv) {
     this_body()->targetted_action("$N $vgive a $o to $t.", liv, ob);
 }
 
-void do_give_obs_to_liv(string *info, object liv) {
+void do_give_obs_to_liv(object *info, object liv) {
     handle_obs(info, (: do_give_obj_to_liv :), liv);
 }
 

--- a/lib/cmds/verbs/look.c
+++ b/lib/cmds/verbs/look.c
@@ -50,7 +50,7 @@ void do_look_at_str(string prep)
     environment(this_body())->do_look_at_str(prep);
 }
 
-void do_look_at_obs(string *info, string name) {
+void do_look_at_obs(object *info, string name) {
     handle_obs(info, (: do_look_at_obj :), name);
 }
 
@@ -62,7 +62,7 @@ void do_look_obj(object ob, string name) {
     do_look_at_obj(ob, name);
 }
 
-void do_look_obs(string *info, string name) {
+void do_look_obs(object *info, string name) {
     handle_obs(info, (: do_look_at_obj :), name);
 }
 
@@ -71,7 +71,7 @@ void do_look_at_obj_with_obj(object o1, object o2) {
     o2->use("look", o1);
 }
 
-void do_look_at_obs_with_obj(string *info, object o2) {
+void do_look_at_obs_with_obj(object *info, object o2) {
     handle_obs(info, (: do_look_at_obj_with_obj :), o2);
 }
 
@@ -79,7 +79,7 @@ void do_look_obj_with_obj(object o1, object o2) {
     do_look_at_obj_with_obj(o1, o2);
 }
 
-void do_look_obs_with_obj(string *info, object o2) {
+void do_look_obs_with_obj(object *info, object o2) {
     handle_obs(info, (: do_look_at_obj_with_obj :), o2);
 }
 
@@ -124,7 +124,7 @@ string look_for_phrase(object ob) {
     return env->query_prep(ob) + " " + env->the_short();
 }
 
-void do_look_for_obs(string *info) {
+void do_look_for_obs(object *info) {
     mixed ua;
     int i, n;
     string res;

--- a/lib/cmds/verbs/put.c
+++ b/lib/cmds/verbs/put.c
@@ -33,7 +33,7 @@ void do_put_obj_wrd_obj(object ob1, string p, object ob2)
   write(tmp);
 }
 
-void do_put_obs_wrd_obj(string *info, string p, object ob2) {
+void do_put_obs_wrd_obj(object *info, string p, object ob2) {
     handle_obs(info, (: do_put_obj_wrd_obj :), p, ob2);
 }
 

--- a/lib/contrib/bboard/news_d.c
+++ b/lib/contrib/bboard/news_d.c
@@ -422,7 +422,7 @@ nomask string * get_groups()
     // expensive
     ret = filter(keys(data), function(string group)
       {
-	  function *a;
+	  mixed *a;
 	  string prefix;
 	  function f;
 	  int i = member_array('.', group, 1) - 1;
@@ -443,7 +443,7 @@ nomask string * get_groups()
 nomask int query_write_to_group( string group )
 {
     function f;
-    function *a;
+    mixed *a;
 
     string prefix;
     int i = member_array('.', group, 1) - 1;

--- a/lib/contrib/board.c
+++ b/lib/contrib/board.c
@@ -17,7 +17,7 @@
 
 // TODO
 // Something to show more than the MAX_HEADERS amount of posts
-// The query_message_lines() returns an *which is then imploded,
+// The query_message_lines() returns an array which is then imploded,
 //   would it not be faster to send a string and not have to implode?
  
 #include <edit.h>

--- a/lib/contrib/marriage/body.c
+++ b/lib/contrib/marriage/body.c
@@ -493,7 +493,7 @@ void channel_rcv_string(string channel_name, string message)
     receive_private_msg(message);
 }
 
-void channel_rcv_soul(string channel_name, *data)
+void channel_rcv_soul(string channel_name, mixed *data)
 {
     string msg;
 
@@ -635,7 +635,7 @@ string in_room_desc() { return base_in_room_desc() + query_idle_string(); }
 
 #ifdef USE_SKILLS
 
-class combat_result *negotiate_result(class combat_result *result)
+class combat_result *negotiate_result(class combat_result mixed *result)
 {
     result = (class combat_result array)::negotiate_result(result);
 

--- a/lib/contrib/marriage/user_d.c
+++ b/lib/contrib/marriage/user_d.c
@@ -7,7 +7,7 @@
 **
 **   mixed * query_variable(string userid, string * varlist)
 **
-**     Return an *of variable values.  0 is returned if
+**     Return an array of variable values.  0 is returned if
 **     the specified user does not exist.
 **
 **

--- a/lib/daemons/channel_d.c
+++ b/lib/daemons/channel_d.c
@@ -560,7 +560,7 @@ nomask int query_flags(string channel_name)
 /*
 ** make_name_list()
 **
-** Make a list of names given an *of players.
+** Make a list of names given an array of players.
 */
 nomask string make_name_list(mixed * list)
 {

--- a/lib/daemons/help_d.c
+++ b/lib/daemons/help_d.c
@@ -31,7 +31,7 @@ private nosave mapping topic_refs =
 
 /*
 ** This mapping contains all the topics in the system.  It
-** maps topic names to an *of pathnames.  The level-
+** maps topic names to an array of pathnames.  The level-
 ** restriction on the topic is then computed by examining
 ** the lead part of the pathname.
 */
@@ -164,7 +164,7 @@ nomask void create()
 ** find_topic()
 **
 ** Will return 0 if the topic does not exist (within the current
-** player's level).  Otherwise, an *of pathnames will be
+** player's level).  Otherwise, an array of pathnames will be
 ** returned.
 */
 nomask string * find_topic(string name)

--- a/lib/daemons/imud/mail.c
+++ b/lib/daemons/imud/mail.c
@@ -18,7 +18,7 @@ private nomask void handle_mail(string mudname,
 				object socket,
 				mixed * message)
 {
-  string *	errors;
+  string * errors;
 
   errors = IMAIL_D->incoming_mail(mudname, message);
   oob_svc_send(socket, ({"mail-ack", ([ message[1] : errors ])}));

--- a/lib/daemons/imud_d.c
+++ b/lib/daemons/imud_d.c
@@ -16,6 +16,12 @@
 #include <log.h>
 #include <ports.h>
 
+// "*Kelly" "45.64.56.66 8080"
+// "*dalet" "97.107.133.86 8787"
+// "*wpr" "195.242.99.94 8080"
+// "*i4" "204.209.44.3 8080" defunct
+// "*gjs" "198.144.203.194 9000" defunct
+
 #define ROUTER "*dalet"
 #define ROUTER_ADDRESS "97.107.133.86 8787"
 
@@ -112,7 +118,7 @@ protected void send_to_router(string type, mixed * message)
     send_message(type, ROUTER, 0, message);
 }
 
-public void send_to_mud(string type, string mudname, mixed * message)
+protected void send_to_mud(string type, string mudname, mixed * message)
 {
     send_message(type, mudname, 0, message);
 }
@@ -137,16 +143,13 @@ protected void return_error(string mudname, string username,
 /* handle reads from the router */
 private nomask void handle_router_read(object socket, mixed * message)
 {
-    // If there's nothing in the message, then return ;
-    if(!sizeof(message)) return ;
-
-    if (message[0]!= "mudlist")
-    {
-        string s = sprintf("%O", message);
-        if ( sizeof(s) > 200 )
-	    s[200..] = "...";
-        //    TBUG(s);
-    }
+if (message[0]!= "mudlist")
+{
+    string s = sprintf("%O", message);
+    if ( sizeof(s) > 200 )
+	s[200..] = "...";
+    //    TBUG(s);
+}
 
     if ( !dispatch[message[0]] )
     {

--- a/lib/daemons/method_d.c
+++ b/lib/daemons/method_d.c
@@ -57,7 +57,7 @@ void remove_method(string method)
 }
 
 //:FUNCTION list_methods
-//Return an *of all methods which have equivalents
+//Return an array of all methods which have equivalents
 string *list_methods()
 {
   return keys(methods);
@@ -105,7 +105,7 @@ void remove_method_equivalents(string method, string *equivs...)
 }
 
 //:FUNCTION list_method_equivalents
-//Return an *of equivalents to a given method
+//Return an array of equivalents to a given method
 string *list_method_equivalents(string method)
 {
   if(member_array(method,keys(methods))==-1)

--- a/lib/daemons/money_d.c
+++ b/lib/daemons/money_d.c
@@ -38,7 +38,7 @@ private mapping rates = ([ ]);
 //Mapping of currency names to plural of the names
 private mapping plurals = ([ ]);
 
-//Mapping of currency names to sorted *of denomination names
+//Mapping of currency names to sorted array of denomination names
 private mapping denominations = ([ ]);
 
 //Mapping of denomination name to class denomination
@@ -72,7 +72,7 @@ nomask string *query_currency_types() {
 }
 
 //:FUNCTION query_denominations
-//Returns the *of denominations of a currency 
+//Returns the array of denominations of a currency 
 //or all available denominations
 varargs nomask string *query_denominations(string type) {
   if (type) {
@@ -319,7 +319,7 @@ varargs nomask string currency_to_string(mixed money, string currency) {
 
 //:FUNCTION handle_subtract_money
 //substracts an amount of currency from a player and adds change.
-//returns an *of two mappings: substract and change, which
+//returns an array of two mappings: substract and change, which
 //consist of the denominations which were used.
 mapping *handle_subtract_money(object player, float f_amount, 
 				     string type) {

--- a/lib/daemons/preposition_d.c
+++ b/lib/daemons/preposition_d.c
@@ -52,7 +52,7 @@ mapping preposition_mappings() {
    return oneword_preps + twoword_preps + threeword_preps;
 }
 
-string *consolidated_preps() {
+mixed *consolidated_preps() {
     return clean_array(values(oneword_preps) + values(twoword_preps) +
                        values(threeword_preps));
 }

--- a/lib/daemons/task_d.c
+++ b/lib/daemons/task_d.c
@@ -15,9 +15,10 @@ inherit M_DAEMON_DATA;
 #define TASK_ATTR 5
 #define TASK_SUB 6
 
-nomask private mixed *find_task(string);
+nomask private *find_task(string);
 
-private mixed *tasks = ({});
+private
+mixed *tasks = ({});
 
 //:FUNCTION query_title
 // Return the title for a given task.
@@ -105,7 +106,7 @@ nomask mixed query_attributes(string task_id)
 
 //:FUNCTION query_sub_tasks
 // Return the sub-tasks for a given task.
-nomask *query_sub_tasks(string task_id)
+nomask mixed *query_sub_tasks(string task_id)
 {
   mixed *task = find_task(task_id);
 
@@ -227,7 +228,7 @@ nomask void clear_attributes(string task_id)
 // --------------------------------------------------------------
 
 //:FUNCTION check_completed
-// Recursively check an *of tasks and
+// Recursively check an array of tasks and
 // return 1 if they are all completed, 0 otherwise.
 nomask private int check_completed(mixed *task_list)
 {
@@ -312,14 +313,14 @@ nomask string resolve_parent_id(string task_id)
 
 //:FUNCTION query_task
 // Return a copy of the specified task.
-nomask *query_task(string task_id)
+nomask mixed *query_task(string task_id)
 {
   return copy(find_task(task_id));
 }
 
 //:FUNCTION query_tasks
 // Return a copy of the tasks array.
-varargs nomask *query_tasks(string task_id)
+varargs nomask mixed *query_tasks(string task_id)
 {
   mixed *task;
 

--- a/lib/domains/std/objects/ocean.c
+++ b/lib/domains/std/objects/ocean.c
@@ -22,8 +22,8 @@ void setup()
    * The second argument is the destination that the body is going to be moved 
    * to when the method is invoked.
    * The third is the check to see if the body can actually use the method,
-   * The fourth argument is an *of possible exit messages
-   * The fifth argument is an *of possible enter messages */
+   * The fourth argument is an array of possible exit messages
+   * The fifth argument is an array of possible enter messages */
   add_method("wade in",
 	     "Outside_Cave",
 	     1,

--- a/lib/domains/std/rooms/Labyrinth.c
+++ b/lib/domains/std/rooms/Labyrinth.c
@@ -28,7 +28,7 @@ int dy(int i) {
 }
 
 void create() {
-    int *valid = allocate(4);
+    mixed *valid = allocate(4);
     int x, y;
     
     data = allocate(SIZE);

--- a/lib/domains/std/rooms/V_Plains.c
+++ b/lib/domains/std/rooms/V_Plains.c
@@ -9,7 +9,7 @@
 **
 ** The data for the plains is pulled from v_plains.data.  It is an array
 ** of description-id values (in the first N non-comment lines).  Comments
-** are lines beginning with #.  After the description *are lists of
+** are lines beginning with #.  After the description array are lists of
 ** rooms for the boundaries of the plains.  They are in north, east,
 ** south, west order; one line per grid spot.
 **

--- a/lib/domains/std/school/R/add_item02.c
+++ b/lib/domains/std/school/R/add_item02.c
@@ -6,7 +6,7 @@ void setup(){
     set_long(@MAY
 
 You can use one description to relate to multiple names.
-Just include all the alternatives as an *at the beginning.
+Just include all the alternatives as an array at the beginning.
 
   add_item( "desk", "table", "furniture" ,
       ([ "look" :

--- a/lib/domains/std/school/R/interactive01.c
+++ b/lib/domains/std/school/R/interactive01.c
@@ -9,7 +9,7 @@ Adapt from the example used in the basic or simple npc.
 
 Start by adding periodic actions, in set_actions.
 First argument - pause between actions (seconds)
-Second argument - string for action, or string *for alternatives.
+Second argument - string for action, or string array for alternatives.
 
   set_actions( 10, ({
     "say What are you waiting for?",

--- a/lib/include/config.h
+++ b/lib/include/config.h
@@ -235,7 +235,7 @@
 /* The administrator(s)' email address(es).
  * NOTE: This is required to be changed in order to have a working
  * I3 system. */
-#define ADMIN_EMAIL		"user@host.name"
+#define ADMIN_EMAIL		"quixadhal@gmail.com"
 
 /* If this is undefined, anonymous ftp is allowed - undef it to prevent.
   Anon ftp users are limited to /ftp/pub.*/

--- a/lib/obj/admtool/mudinfo/memory.c
+++ b/lib/obj/admtool/mudinfo/memory.c
@@ -12,7 +12,7 @@ nomask string module_key() {
 
 private void obj_and_prog() {
     mapping info = ([]);
-    string *k;
+    mixed *k;
     string ret;
     
     foreach (object o in objects())

--- a/lib/obj/mudlib/helpsys.c
+++ b/lib/obj/mudlib/helpsys.c
@@ -52,7 +52,7 @@ string *shorten(string *names)
     if(sizeof(t)>1)
       dup += ({t[0]});
 
-// dup is now an *of duplicate names
+// dup is now an array of duplicate names
 
   for(int j=0;j<sizeof(names);j++)
   {

--- a/lib/obj/mudlib/pshell.c
+++ b/lib/obj/mudlib/pshell.c
@@ -81,7 +81,7 @@ protected void execute_command(string original_input)
 {
   string * argv = explode(original_input, " ");
   mixed tmp;
-  mixed winner;
+  mixed *winner;
   string argument;
 
 /* BEGINNING OF EXPANSION */

--- a/lib/obj/secure/mailers/mailer.c
+++ b/lib/obj/secure/mailers/mailer.c
@@ -65,7 +65,7 @@ protected nomask int get_message_key(int user_num)
 /*
 ** format_name_list()
 **
-** Format a list of names (as in To: or CC:).  Returns an *of lines.
+** Format a list of names (as in To: or CC:).  Returns an array of lines.
 */
 protected nomask string * format_name_list(string prompt, string * names)
 {
@@ -80,7 +80,7 @@ protected nomask string * format_name_list(string prompt, string * names)
 /*
 ** build_message()
 **
-** Build an *of strings containing a mail message.
+** Build an array of strings containing a mail message.
 */
 protected nomask string * build_message(int mail_key, int supress_header)
 {
@@ -111,7 +111,7 @@ protected nomask string * build_message(int mail_key, int supress_header)
 /*
 ** write_dead_letter()
 **
-** Write the *of lines to the wizard's dead.letter.  Does nothing
+** Write the array of lines to the wizard's dead.letter.  Does nothing
 ** if the player is not a wizard or no home dir exists.
 */
 protected nomask void write_dead_letter(string * buf)
@@ -129,7 +129,7 @@ protected nomask void write_dead_letter(string * buf)
 /*
 ** build_body_inclusion()
 **
-** Build an *of lines for the body of a message to be included into
+** Build an array of lines for the body of a message to be included into
 ** another message (prefixed with "> ")
 */
 protected nomask string * build_body_inclusion(string * body)

--- a/lib/obj/secure/shell/alias.c
+++ b/lib/obj/secure/shell/alias.c
@@ -234,7 +234,7 @@ add_alias(string name, string template, string* defaults, int xverb)
 		     sscanf(s, "%d%s",d,s);
 		     return d;}));
 
-// Pad the default *with empty strings if there aren't enough
+// Pad the default array with empty strings if there aren't enough
 // defaults provided to us.
   if(!arrayp(new_alias->defaults))
     new_alias->defaults = ({});

--- a/lib/obj/secure/shell/getopt.c
+++ b/lib/obj/secure/shell/getopt.c
@@ -17,9 +17,9 @@ int classify( int opt, string options ){
 
 
 //:FUNCTION getopt
-//Takes an *and parses flags from it. Returns an array, the first
+//Takes an array and parses flags from it. Returns an array, the first
 //element being a mapping of flag : value, the second element being an
-//*of the remaining args, all flag information removed.  The second
+//array of the remaining args, all flag information removed.  The second
 //argument should be a string of single character flags that the command
 //accepts, followed by a colon (:) if the flag can take an argument.
 mixed
@@ -76,7 +76,7 @@ getopt( mixed args, string options )
 //assumes the arg passed is the argument to some unix-like
 //command where ares are space seperated unless enclosed in non-escaped
 //quotes.
-//Returns an *of the arguments. and an *of implode info
+//Returns an array of the arguments. and an *of implode info
 
 mixed* argument_explode(string s)
 {

--- a/lib/obj/secure/webed.c
+++ b/lib/obj/secure/webed.c
@@ -82,7 +82,7 @@ string format_editor(string user, string password, string filename,
   output = output + "</table>\n";
   if (contents)
     {
-	string *inh;
+	mixed *inh;
 	object ob;
 
 	output +="<hr><font size=+1><strong>Editing: " + HTML_encode(filename) + "</strong></font><p>";

--- a/lib/obj/tasktool/internal/base.c
+++ b/lib/obj/tasktool/internal/base.c
@@ -18,7 +18,7 @@ class command_info {
     string desc;     // A short [~40 chars] description of the command
     string priv;     // priv required to use this command
     string status;      // A short [~10 chars] description of task status
-    mixed *args;      // An *of prompts to use to ask for arguments not
+    mixed *args;      // An array of prompts to use to ask for arguments not
     // given on the line.  Max == 2.
     function action; // The function to be called.
 }

--- a/lib/secure/daemons/lpscript_d.c
+++ b/lib/secure/daemons/lpscript_d.c
@@ -110,7 +110,7 @@ void do_errors() {
 	error("Script compilation failed:\n" + implode(errors, "\n") + "\n");
 }
 
-string *line_info() {
+mixed *line_info() {
     if (linesync) {
 	linesync = 0;
 	return ({ cur });
@@ -118,7 +118,7 @@ string *line_info() {
     return ({});
 }
 
-string *parse_long_string() {
+mixed *parse_long_string() {
     int first = cur;
     string ind;
     int indent;

--- a/lib/secure/daemons/user_d.c
+++ b/lib/secure/daemons/user_d.c
@@ -7,7 +7,7 @@
 **
 **   mixed * query_variable(string userid, string * varlist)
 **
-**     Return an *of variable values.  0 is returned if
+**     Return an array of variable values.  0 is returned if
 **     the specified user does not exist.
 **
 **

--- a/lib/secure/modules/m_save.c
+++ b/lib/secure/modules/m_save.c
@@ -29,7 +29,7 @@ protected void add_save(mixed *vars) {
 }
 
 //:FUNCTION get_saved
-//returns the *of variables that get saved.
+//returns the array of variables that get saved.
 
 //###Security problem here - Beek.  What is it used for anyway?
 string *get_saved() { return saved; }

--- a/lib/secure/simul_efun/misc.c
+++ b/lib/secure/simul_efun/misc.c
@@ -47,7 +47,7 @@ call_trace() {
 // There should be an | operator for this.
 
 //:FUNCTION clean_array
-//returns a version of the passed *with duplicate
+//returns a version of the passed array with duplicate
 //entries removed.  Eg, clean_array(({1,2,2}))  => ({1,2})
 mixed*
 clean_array(mixed* r) {
@@ -140,8 +140,8 @@ int cmp( mixed a, mixed b )
 
 
 //:FUNCTION insert
-//Inserts the contents of the *of the first argument into
-//The *in the second argument before the nth element of the array,
+//Inserts the contents of the array of the first argument into
+//The array in the second argument before the nth element of the array,
 //where n is the 3rd argument passed to insert.
 
 // Rust hacked at this to make it a bit more intuitive...
@@ -155,7 +155,7 @@ mixed insert( mixed 	to_insert,
   if( !arrayp( to_insert ) )
     return (void)error("Bad type arg 1 to simul efun insert()");
 
-  if( !arrayp( into_*) )
+  if( !arrayp( into_array ) )
     return (void)error("Bad type arg 2 to simul efun insert()");
 
   if( !intp( where ) )
@@ -371,7 +371,7 @@ varargs mixed eval( string arg, string includefile )
 //will return: ({1,2,3,4}).  The algorithm is not recursive, so if any of
 //the arrays have arrays in them, those arrays remain intact.  Eg,
 //decompose( ({1,({({2,3}),4}),5}) )  returns:({1,({2,3}),4,5}).
-//See flatten_*for a recursive version.
+//See flatten_array for a recursive version.
 
 mixed* decompose( mixed* org )
 {
@@ -393,7 +393,7 @@ mixed* decompose( mixed* org )
 
 //:FUNCTION choice
 //Returns a random element of the structure passed, if that
-// is an aggregate type (i.e., A string, *or mapping).
+// is an aggregate type (i.e., A string, array or mapping).
 
 mixed choice( mixed f ){
     mixed *k;
@@ -422,7 +422,7 @@ else
 
 //:FUNCTION max
 //Returns the largest element of a structure that is a string,
-//*or mapping.
+//array or mapping.
 
 mixed max( mixed f ){
   if(stringp(f)) f = explode(f," ");
@@ -433,7 +433,7 @@ else
 }
 
 //:FUNCTION flatten_array
-//Takes a *that may contain arrays, and reduces all
+//Takes an array that may contain arrays, and reduces all
 //arrays so that the result is a one dimensional array
 
 mixed

--- a/lib/secure/simul_efun/more.c
+++ b/lib/secure/simul_efun/more.c
@@ -19,7 +19,7 @@ private nomask int default_num()
 }
 
 //:FUNCTION more
-//more(arg) starts up more to display the *of lines 'arg'.  If arg is
+//more(arg) starts up more to display the array of lines 'arg'.  If arg is
 //a string, it is exploded around "\n".  An optional second argument gives
 //the number of lines per chunk.  An optional continuation function will
 //be evaluated when the "more" is completed.
@@ -52,7 +52,7 @@ varargs nomask void more(mixed arg, int num, function continuation,
 
 //:FUNCTION more_file
 //more_file(arg) starts up more to display the single file 'arg' if 'arg'
-//is a string, or more than one file if 'arg' is an *of strings.
+//is a string, or more than one file if 'arg' is an array of strings.
 //An optional second argument gives the number of lines per chunk.  An
 //optional continuation function will be evaluated when the "more" is
 //completed.

--- a/lib/secure/simul_efun/overrides.c
+++ b/lib/secure/simul_efun/overrides.c
@@ -156,7 +156,8 @@ void say(string m)
     error("say() not available. Consider using this_body()->other_action()\n");
 }
 
-void printf(string format, string *rest...) {
+// Needs to be mixed, since you can pass in floats, ints, and whatever.
+void printf(string format, mixed *rest...) {
     if (this_user())
 	tell(this_user(), sprintf(format, rest...));
     else

--- a/lib/secure/user/history.c
+++ b/lib/secure/user/history.c
@@ -32,7 +32,7 @@ void add_tell_history(string add) {
   /* Strip trailing \n's */
   if(add[<1]=='\n')
     add=add[0..<2];
-  /* Add the history item to the end of the **/
+  /* Add the history item to the end of the array */
   tell_history+=({add});
   size=sizeof(tell_history);
   if(size>CHANNEL_HISTORY_SIZE) { 

--- a/lib/secure/user/messages.c
+++ b/lib/secure/user/messages.c
@@ -51,11 +51,11 @@ void set_colour(string which, string what) {
     save_me();
 }
 
-string query_colour(string which) {
+void query_colour(string which) {
     return colours[which];
 }
 
-string *query_colours() {
+mixed *query_colours() {
     return keys(colours);
 }
 

--- a/lib/std/adversary/armor/simple_slots.c
+++ b/lib/std/adversary/armor/simple_slots.c
@@ -61,7 +61,7 @@ nomask int has_body_slot(string what)
 
 //:FUNCTION query_armor_slots
 // string *query_armor_slots();
-// Returns an *of all valid armor slots.
+// Returns an array of all valid armor slots.
 string *query_armor_slots()
 {
    return keys(slots);

--- a/lib/std/adversary/condition.c
+++ b/lib/std/adversary/condition.c
@@ -6,7 +6,7 @@ private nosave int stunned; // time to awake from stunned status
 private int asleep;         // flag for "asleep" status
 private nosave int chance;  // counter for attempted "wake up"
 private nosave int attack_speed = 1;
-private nosave object * readied = ({}); // *of ready ammunition
+private nosave object * readied = ({}); // array of ready ammunition
 
 void add_readied(object ob)
 {

--- a/lib/std/adversary/health/limbs.c
+++ b/lib/std/adversary/health/limbs.c
@@ -71,7 +71,7 @@ int is_attacking_limb(string limb)
 
 //:FUNCTION query_limbs
 // string *query_limbs();
-// Returns a string *containing all limbs that health is applied to.
+// Returns a string array containing all limbs that health is applied to.
 string *query_limbs()
 {
    return keys(health);
@@ -79,7 +79,7 @@ string *query_limbs()
 
 //:FUNCTION query_wielding_limbs
 // string *query_wielding_limbs();
-// Returns a string *containing all the limbs that can wield weapons.
+// Returns a string array containing all the limbs that can wield weapons.
 string *query_wielding_limbs()
 {
    return filter(keys(health), (: ((class limb)health[$1])->flags & LIMB_WIELDING :));
@@ -87,7 +87,7 @@ string *query_wielding_limbs()
 
 //:FUNCTION query_attacking_limbs
 // string *query_attacking_limbs();
-// Returns a string *containing all the limba that can attack.
+// Returns a string array containing all the limba that can attack.
 string *query_attacking_limbs()
 {
    return filter(keys(health), (: ((class limb)health[$1])->flags &
@@ -96,7 +96,7 @@ LIMB_ATTACKING :));
 
 //:FUNCTION query_vital_limbs
 // string *query_vital_limbs();
-// Returns a string *containing all the limbs that are considered
+// Returns a string array containing all the limbs that are considered
 // vital for survival. If any one of these limbs is disabled, the
 // adversary dies.
 string *query_vital_limbs()
@@ -115,7 +115,7 @@ string *query_mobile_limbs()
 
 //:FUNCTION query_system_limbs
 // string *query_system_limbs();
-// Returns a string *of 'system' limbs. When ALL system limbs are
+// Returns a string array of 'system' limbs. When ALL system limbs are
 // disabled, the adversary dies.
 string *query_system_limbs()
 {

--- a/lib/std/adversary/health/wounds.c
+++ b/lib/std/adversary/health/wounds.c
@@ -16,7 +16,7 @@ class diagnosis
 string number_word(int);       /* M_GRAMMAR */
 string number_of(int, string);
 
-/* Value is an *of numbers, indicating the size of the wounds.  Note
+/* Value is an array of numbers, indicating the size of the wounds.  Note
  * that the sum of wounds[limb] should ALWAYS be health[limb]->max_health
  * minus health[limb]->health.
  *

--- a/lib/std/base_room.c
+++ b/lib/std/base_room.c
@@ -102,7 +102,7 @@ void mudlib_setup()
 
 //:FUNCTION set_area
 //Used by m_wander to prevent monsters from wandering to far.
-//Can either be a string, or an *of strings
+//Can either be a string, or an array of strings
 void set_area(string *names...)
 {
     area_names = names;

--- a/lib/std/body/history.c
+++ b/lib/std/body/history.c
@@ -32,7 +32,7 @@ void add_say_history(string add) {
   /* Strip trailing \n's */
   if(add[<1]=='\n')
     add=add[0..<2];
-  /* Add the history item to the end of the **/
+  /* Add the history item to the end of the array */
   say_history+=({add});
   size=sizeof(say_history);
   if(size>CHANNEL_HISTORY_SIZE) { 

--- a/lib/std/book.c
+++ b/lib/std/book.c
@@ -159,7 +159,7 @@ private nomask string query_last_page()
 }
 
 //:FUNCTION set_pages
-//Set the pages that are in the book.  Each element of the *is the text
+//Set the pages that are in the book.  Each element of the array is the text
 //that appears on the page.  The elements can be either the text that is on the
 //page, a filename, or a function pointer that generates one of these.
 void set_pages(mixed *page_data...)

--- a/lib/std/classes/mailmsg.c
+++ b/lib/std/classes/mailmsg.c
@@ -18,6 +18,6 @@ class mail_msg
     int		thread_id;	/* first msg's id (date) */
     string *	body;		/* body of msg */
   // IMUD_MAIL doesn't need to know WHO hasn't deleted the message, so
-  // it just uses a number.  regular mail uses an *of names.
+  // it just uses a number.  regular mail uses an array of names.
     mixed	dels_pending;	/* these users must delete msg */
 }

--- a/lib/std/container.c
+++ b/lib/std/container.c
@@ -199,7 +199,7 @@ void remove_relation_alias(string relation,string aliases...)
 }
 
 //:FUNCTION query_relation_aliases
-//Return the *of aliases that a relation has.
+//Return the array of aliases that a relation has.
 string *query_relation_aliases(string relation)
 {
   return relation_aliases[relation];
@@ -710,7 +710,7 @@ varargs mixed *set_objects(mapping m,string relation) {
 //:FUNCTION set_unique_objects
 //Provide a list of objects to be loaded now and at every reset if they
 //are not already loaded.  The key should be the filename of the object, 
-//and the value should be an *which is passed to create() when the 
+//and the value should be an array which is passed to create() when the 
 //objects are cloned.
 //The structure of the mapping should be the same as the structure of the 
 //mapping for set_objects().  For unique objects, to be checked, you should

--- a/lib/std/grid_server.c
+++ b/lib/std/grid_server.c
@@ -8,9 +8,9 @@
 **	/serverfname/x/y
 **
 ** The data for the server is pulled from the data file provided at
-** create() time.  It is an *of description-id values (in the
+** create() time.  It is an array of description-id values (in the
 ** first N non-comment lines).  Comments are lines beginning with #.
-** After the description *are lists of rooms for the boundaries
+** After the description array are lists of rooms for the boundaries
 ** of the grid.  They are in north, east, south, west order; one line
 ** per grid spot.
 **

--- a/lib/std/living/effects.c
+++ b/lib/std/living/effects.c
@@ -92,7 +92,7 @@ int find_effect_name_index(string name)
 }
 
 //:FUNCTION find_effect_indexes_matching
-// Return *of positions of effects (part-)matching specified name
+// Return array of positions of effects (part-)matching specified name
 // Return ({})
 int *find_effect_indexes_matching(string name)
 {
@@ -302,7 +302,7 @@ void clear_effects()
 
 //:FUNCTION query_effects
 // Returns copy of the effects queue
-*query_effects() { return copy(effects); }
+mixed *query_effects() { return copy(effects); }
 
 //:FUNCTION add_effect
 // Adds the specified effect

--- a/lib/std/living/state_of_mind.c
+++ b/lib/std/living/state_of_mind.c
@@ -73,7 +73,7 @@ mixed check_condition(int urgent) {
 	if (urgent) {
 	    if (random(5)<=chance++) {
 		wake_up();
-//FIXME: print_result takes a class combat_result *now.
+//FIXME: print_result takes a class combat_result array now.
 #if 0
 		print_result("wakeup");
 #endif

--- a/lib/std/modules/m_actions.c
+++ b/lib/std/modules/m_actions.c
@@ -15,12 +15,11 @@ void action_departure(object);
 private nosave function arrival_fn = (: action_arrival :);
 private nosave function departure_fn = (: action_departure :);
 
-private function            my_hook;
-private nosave string *response_queue = ({ });
-private int                 delay_time = 5;
-private string *       my_actions;
-
-private object              env;
+private function         my_hook;
+private nosave string   *response_queue = ({ });
+private int              delay_time = 5;
+private string          *my_actions;
+private object           env;
 
 mixed need_hooks() { return 1; }
 

--- a/lib/std/modules/m_complete.c
+++ b/lib/std/modules/m_complete.c
@@ -10,7 +10,7 @@
 
 //:FUNCTION complete
 //Given a string and a list of possible completions of that string,
-//return an *of all strings that would be valid completions.
+//return an array of all strings that would be valid completions.
 
 string* complete(string partial, string* potentials)
 { 
@@ -44,7 +44,7 @@ string *find_best_match_or_complete(string partial, string *potentials)
 
 //:FUNCTION complete_user
 //given a username that might be partial, returns a
-//user name, or an *of strings on a partial match, or 0 on no match.
+//user name, or an array of strings on a partial match, or 0 on no match.
 
 mixed complete_user(string name)
 {

--- a/lib/std/modules/m_complex_exit.c
+++ b/lib/std/modules/m_complex_exit.c
@@ -68,7 +68,7 @@ private string *all_methods_matched(string method)
     return matches;
 }
 
-/* Return an *of all of the methods which might match the method passed
+/* Return an array of all of the methods which might match the method passed
  * to the function.  It breaks down the preposition to it's lowest form before
  * making its determination, allowing for the fullest range of possible forms.
  */
@@ -176,8 +176,8 @@ string query_direction()
 //Setup a go method.  The first argument is the verb to be used, the second 
 //argument is the destination to move the body to when invoked successfully,
 //the third argument is the check to be performed before invoking the method
-//the fourth argument is an *of possible exit messages, and the fifth
-//argument is an *of possible enter messages.  Only the first two
+//the fourth argument is an array of possible exit messages, and the fifth
+//argument is an array of possible enter messages.  Only the first two
 //arguments are required, the rest are optional.
 varargs void set_method(string method,mixed destination,mixed checks,mixed *exit_messages,mixed *enter_messages)
 {
@@ -216,8 +216,8 @@ varargs void set_method(string method,mixed destination,mixed checks,mixed *exit
 //Add a go method.  The first argument is the verb to be used, the second 
 //argument is the destination to move the body to when invoked successfully,
 //the third argument is the check to be performed before invoking the method
-//the fourth argument is an *of possible exit messages, and the fifth
-//argument is an *of possible enter messages.  Only the first two
+//the fourth argument is an array of possible exit messages, and the fifth
+//argument is an array of possible enter messages.  Only the first two
 //arguments are required, the rest are optional.
 varargs void add_method(string method,mixed destination,mixed checks,mixed *exit_messages,mixed *enter_messages)
 {
@@ -311,7 +311,7 @@ mixed query_method_destination(string method)
 
 //:FUNCTION set_method_enter_messages
 //Set the enter messages to be used by the given method.  
-//Acceptable arguments are strings, or function pointers, or an *of 
+//Acceptable arguments are strings, or function pointers, or an array of 
 //either (mixed is acceptable)
 //The method is to be seen by the bodies in the room that the body is entering
 varargs void set_method_enter_messages(string method,mixed *messages...)
@@ -326,7 +326,7 @@ varargs void set_method_enter_messages(string method,mixed *messages...)
 
 //:FUNCTION add_method_enter_messages
 //Add the enter messages to be used by the given method.  
-//Acceptable arguments are strings, or function pointers, or an *of 
+//Acceptable arguments are strings, or function pointers, or an array of 
 //either (mixed is acceptable)
 //The method is to be seen by the bodies in the room that the body is entering
 varargs void add_method_enter_messages(string method,mixed messages...)
@@ -341,7 +341,7 @@ varargs void add_method_enter_messages(string method,mixed messages...)
 
 //:FUNCTION remove_method_enter_messages
 //Remove the enter messages to be used by the given method.  
-//Acceptable arguments are strings, or function pointers, or an *of 
+//Acceptable arguments are strings, or function pointers, or an array of 
 //either (mixed is acceptable)
 //The method is to be seen by the bodies in the room that the body is entering
 varargs void remove_method_enter_messages(string method,mixed messages...)
@@ -379,7 +379,7 @@ string query_method_enter_message(string method)
 }
 
 //:FUNCTION list_method_enter_messages
-//Return an *of the method's enter messages
+//Return an array of the method's enter messages
 mixed *list_method_enter_messages(string method)
 {
     string *applicable_methods=methods_matched(method);
@@ -392,7 +392,7 @@ mixed *list_method_enter_messages(string method)
 
 //:FUNCTION set_method_exit_messages
 //Set the exit messages to be used by the given method.  
-//Acceptable arguments are strings, or function pointers, or an *of 
+//Acceptable arguments are strings, or function pointers, or an array of 
 //either (mixed is acceptable)
 //The method is to be seen by the bodies in the room that the body is exiting
 varargs void set_method_exit_messages(string method,mixed messages...)
@@ -407,7 +407,7 @@ varargs void set_method_exit_messages(string method,mixed messages...)
 
 //:FUNCTION add_method_exit_messages
 //Add the exit messages to be used by the given method.  
-//Acceptable arguments are strings, or function pointers, or an *of 
+//Acceptable arguments are strings, or function pointers, or an array of 
 //either (mixed is acceptable)
 //The method is to be seen by the bodies in the room that the body is exiting
 varargs void add_method_exit_messages(string method,mixed messages...)
@@ -422,7 +422,7 @@ varargs void add_method_exit_messages(string method,mixed messages...)
 
 //:FUNCTION remove_method_exit_messages
 //Remove the exit messages to be used by the given method.  
-//Acceptable arguments are strings, or function pointers, or an *of 
+//Acceptable arguments are strings, or function pointers, or an array of 
 //either (mixed is acceptable)
 //The method is to be seen by the bodies in the room that the body is exiting
 varargs void remove_method_exit_messages(string method,mixed messages...)
@@ -451,7 +451,7 @@ string query_method_exit_message(string method)
 	return;
 
     ret=methods[applicable_methods[0]]->exit_messages;
-    /* We know that ret has to be an *at this point, select one element
+    /* We know that ret has to be an array at this point, select one element
      * randomly */
     ret=ret[random(sizeof(ret))];
     /* Evaluate it on the chance it's a function pointer */
@@ -460,7 +460,7 @@ string query_method_exit_message(string method)
 }
 
 //:FUNCTION list_method_exit_messages
-//Return an *of the method's exit messages
+//Return an array of the method's exit messages
 mixed *list_method_exit_messages(string method)
 {
     string *applicable_methods=methods_matched(method);

--- a/lib/std/modules/m_drinkable.c
+++ b/lib/std/modules/m_drinkable.c
@@ -29,7 +29,7 @@ void remove();
 //fluid.  'x' is evaluated when the
 //fluid is drunk.  By default it is
 //a my_action, but it could be a
-//function or an *of mixed.
+//function or an array of mixed.
 //To have no taste action, pass a
 //zero.
 void set_taste_action( mixed x ){
@@ -46,7 +46,7 @@ mixed get_taste_action(){
 //fluid.  'x' is evaluated when the
 //fluid is drunk.  By default it is
 //a simple_action, but it could be a
-//function or an *of mixed.
+//function or an array of mixed.
 //To have no drink action, pass a
 //zero.
 void set_drink_action(mixed action) {

--- a/lib/std/modules/m_follow.c
+++ b/lib/std/modules/m_follow.c
@@ -39,7 +39,7 @@ private nosave int following;
 //Strings must be an id of the object which you want to have 
 //followed.
 //If a function pointer is used it must return a string, object
-//or an *of objects and strings.  An argument of this_object
+//or an array of objects and strings.  An argument of this_object
 //is passed to the function pointer.
 void set_follow_search(mixed *follow...)
 {
@@ -62,7 +62,7 @@ void remove_follow_search(mixed *follow...)
 }
 
 //:FUNCTION clear_follow_search
-//Clears the search *for following
+//Clears the search array for following
 void clear_follow_search()
 {
   follow_search=({});

--- a/lib/std/modules/m_messages.c
+++ b/lib/std/modules/m_messages.c
@@ -90,7 +90,7 @@ string *query_msg_types()
       keys(MESSAGES_D->get_messages(def_message_type)));
 }
 
-string *handle_obs(mixed *obs, string res, mapping has)
+mixed *handle_obs(mixed *obs, string res, mapping has)
 {
   string *ret = ({});
   mapping items = ([]);
@@ -160,7 +160,7 @@ string *handle_obs(mixed *obs, string res, mapping has)
   return ({ res, ret });
 }
 
-string *handle_ob(mixed ob, string res, mapping has)
+*handle_ob(mixed ob, string res, mapping has)
 {
   string bit;
 
@@ -191,7 +191,7 @@ string *handle_ob(mixed ob, string res, mapping has)
 
 //:FUNCTION compose_message
 //The lowest level message composing function; it is passed the object
-//for whom the message is wanted, the message string, the *of people
+//for whom the message is wanted, the message string, the array of people
 //involved, and the objects involved.  It returns the appropriate message.
 //Usually this routine is used through the higher level interfaces.
 varargs string compose_message(object forwhom, string msg, object *who, 
@@ -385,7 +385,7 @@ varargs string compose_message(object forwhom, string msg, object *who,
 
 //:FUNCTION action
 //Make the messages for a given group of people involved.  The return
-//value will have one *per person, as well as one for anyone else.
+//value will have one array per person, as well as one for anyone else.
 //inform() can be used to send these messages to the right people.
 //see: inform
 
@@ -406,11 +406,11 @@ varargs string *action(object *who, mixed msg, mixed *obs...)
 //### This now always indents continuation lines.  Might want a flag at the
 //### end to enable or disable that.
 //:FUNCTION inform
-//Given an *of participants, and an *of messages, and either an
-//object or *of objects, deliver each message to the appropriate
+//Given an array of participants, and an array of messages, and either an
+//object or array of objects, deliver each message to the appropriate
 //participant, being careful not to deliver a message twice.
 //The last arg is either a room, in which that room is told the 'other'
-//message, or an *of people to recieve the 'other' message.
+//message, or an array of people to recieve the 'other' message.
 void inform(object *who, string *msgs, mixed others)
 {
   int i;

--- a/lib/std/modules/m_react.c
+++ b/lib/std/modules/m_react.c
@@ -13,11 +13,11 @@ class parse_info {
     int term;
 }
 
-private string *parse_file(class parse_info pi, string *term) {
-    string *program = ({});
+private mixed *parse_file(class parse_info pi, string *term) {
+    mixed *program = ({});
     string keyword;
     int tmp;
-    string *tmparr;
+    mixed *tmparr;
     string arg1, arg2;
     
     while (pi->cur < sizeof(pi->lines)) {
@@ -143,7 +143,7 @@ string parse_literal(string expr) {
     return expr;
 }
 
-string parse_expr1(mixed *parts) {
+string parse_expr1(string *parts) {
     string expr1, expr2;
     string token = parts[parts[0]++];
     
@@ -171,7 +171,7 @@ string parse_expr1(mixed *parts) {
  * expr: expr1 |
  *       expr1 infix expr
  */
-string parse_expr(mixed *parts) {
+string parse_expr(string *parts) {
     string expr1, expr2;
     string token;
     
@@ -199,7 +199,7 @@ string handle_set(string lhs, string rhs) {
     return "  var_" + lhs[1..] + " = " + handle_expression(rhs) + ";\n";
 }
 
-void compile_func(mapping funcs, string sname, string *prog) {
+void compile_func(mapping funcs, string sname, mixed *prog) {
     int i;
     string ssname;
     mixed prog_stack = ({ "", prog });
@@ -267,7 +267,7 @@ void compile_func(mapping funcs, string sname, string *prog) {
     }
 }
 
-string compile_program(class parse_info pi, string *prog) {
+string compile_program(class parse_info pi, mixed *prog) {
     mapping funcs = ([]);
     string ret;
     
@@ -316,7 +316,7 @@ void receive_private_msg(string str) {
 	
 void compile_script(string fname) {
     class parse_info pi;
-    string *program;
+    mixed *program;
     object ob;
     
     if (script) destruct(script);

--- a/lib/std/modules/m_ready.c
+++ b/lib/std/modules/m_ready.c
@@ -5,14 +5,14 @@
 // to interact with the "ready" verb which prepares for firing
 
 //:FUNCTION do_ready
-// Adds the object to the "ready" *of ammunition
+// Adds the object to the "ready" array of ammunition
 void do_ready()
 {
   this_body()->add_readied(this_object());
 }
 
 //:FUNCTION do_unready
-// Removes the object from the "ready" *of ammunition
+// Removes the object from the "ready" array of ammunition
 void do_unready()
 {
   this_body()->remove_readied(this_object());

--- a/lib/std/modules/m_searchable.c
+++ b/lib/std/modules/m_searchable.c
@@ -16,7 +16,7 @@ void searchable_once(int i) { once = i; }
 int query_search_once() { return once; }
 
 //:FUNCTION searchable_with
-//Give an *of filenames that can be used to search this object.
+//Give an array of filenames that can be used to search this object.
 void searchable_with(string *filenames) { with = filenames; }
 string *query_searchable_with() { return with; }
 

--- a/lib/std/modules/m_trainer.c
+++ b/lib/std/modules/m_trainer.c
@@ -25,7 +25,7 @@ void set_trainer_msgs( mapping msgs )
 }
 
 
-void set_train_restrict( *restrictions )
+void set_train_restrict( string *restrictions )
 {
     string *valid_skills = SKILL_D->query_skills();
 

--- a/lib/std/modules/m_vendor.c
+++ b/lib/std/modules/m_vendor.c
@@ -142,7 +142,7 @@ void add_sell_object(object ob) {
 }
 
 //:FUNCTION set_for_sale
-//Set the *of object names which this living object is willing to sell.
+//Set the array of object names which this living object is willing to sell.
 //set_for_sale(1) means everything is for sale.  set_for_sale(0) means nothing
 //is.  If a function is passed it will get the object to sell as argument.
 //If a single string is returned it will be used as error message.
@@ -155,7 +155,7 @@ mixed query_for_sale() {
 }
 
 //:FUNCTION set_will_buy
-//Set the *of object names which this living object is willing to buy.
+//Set the array of object names which this living object is willing to buy.
 //set_will_buy(1) means it will buy anything.  set_will_buy(0) means it wont
 //by anything.  If a function is passed it will get the object to buy as
 //argument. If a single string is returned it will be used as error message.

--- a/lib/std/modules/m_wander.c
+++ b/lib/std/modules/m_wander.c
@@ -70,7 +70,7 @@ void clear_wander_area()
 }
 
 //:FUNCTION query_wander_area
-//Returns an *of areas in which may wander.  
+//Returns an array of areas in which may wander.  
 //See set_wander_area()
 string *query_wander_area()
 {

--- a/lib/std/object/attributes.c
+++ b/lib/std/object/attributes.c
@@ -11,7 +11,7 @@
 
 /*
 ** The key is a flag value (see /include/flags.h) and the values are a
-** string or an *of three strings.  For the first case, the string will
+** string or an array of three strings.  For the first case, the string will
 ** be used if the flag is set. For the latter case: if the object responds
 ** TRUE to the function specified in the third string, then the first
 ** string (at index 0) will be used if the flag is off, and the second

--- a/lib/std/object/description.c
+++ b/lib/std/object/description.c
@@ -75,7 +75,8 @@ string long()
   return ret;
 }
 
-protected string *discarded_message, plural_discarded_message;
+protected string *discarded_message;
+protected string *plural_discarded_message;
 
 string untouched_long() {
     return untouched_long;

--- a/lib/std/object/names.c
+++ b/lib/std/object/names.c
@@ -293,7 +293,7 @@ void clear_adj()
 /****** query_ ******/
 
 //:FUNCTION query_id
-//Returns an *containing the ids of an object
+//Returns an array containing the ids of an object
 string *query_id() {
     string *fake = this_object()->fake_item_id_list();
 

--- a/lib/trans/cmds/findfile.c
+++ b/lib/trans/cmds/findfile.c
@@ -117,7 +117,7 @@ private void main(mixed * arg, mapping flags)
     begin_database_build();
     return;
   } else {
-/* arg[0] is an *of strings. use just the first */
+/* arg[0] is an array of strings. use just the first */
     find = arg[0];
     ed_start(DATA_FILE);
     outstr = ed_cmd(sprintf("1,$g#%s#p", find));

--- a/lib/trans/cmds/more.c
+++ b/lib/trans/cmds/more.c
@@ -11,7 +11,7 @@ inherit CMD;
 //
 // Prints out the lines of a file
 
-// we will recieve  : ({ *of files })
+// we will recieve  : ({ array of files })
 
 private void main(mixed *arg, mapping flags, string stdin)
 {

--- a/lib/trans/obj/edit_ob.c
+++ b/lib/trans/obj/edit_ob.c
@@ -14,7 +14,7 @@
 ** "func" will be evaluated when the editing is complete.  One
 ** parameter will be passed, which will be zero if the editing
 ** was aborted for some reason.  Otherwise, it will be a single
-** string specifying the file name, or an *of strings
+** string specifying the file name, or an array of strings
 ** holding the lines of text.
 */
 


### PR DESCRIPTION
These are all the things I could find in the array -> * conversion effort.
In a few cases, I changed the type from string * to mixed * if it made sense.
I also restored the word "array" in lots of comments and documents.